### PR TITLE
Add `IEnumerable<double> Samples` to `ISampleMonitor`

### DIFF
--- a/src/SimSharp/Analysis/IMonitor.cs
+++ b/src/SimSharp/Analysis/IMonitor.cs
@@ -6,6 +6,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 
 namespace SimSharp {
   public interface IMonitor {
@@ -34,6 +35,7 @@ namespace SimSharp {
 
   public interface ISampleMonitor : INumericMonitor {
     void Add(double value);
+    IEnumerable<double> Samples { get; }
   }
 
   public interface ITimeSeriesMonitor : INumericMonitor {


### PR DESCRIPTION
The field `IEnumerable<double> Samples` is already present on
`SampleMonitor`, but it's missing from `ISampleMonitor`, which requires
a (potentially dangerous) cast.

To make the cast unnecessary, add it to the interface.