### PR TITLE
Fix empty fuel pump bug in GasStationRefueling sample

### DIFF
--- a/src/Samples/GasStationRefueling.cs
+++ b/src/Samples/GasStationRefueling.cs
@@ -55,7 +55,7 @@ namespace SimSharp.Samples {
 
         // Get the required amount of fuel
         var litersRequired = FuelTankSize - fuelTankLevel;
-        if (litersRequired > fuelPump.Level) {
+        if (litersRequired > fuelPump.Level && fuelPump.Level > 0) {
           var level = fuelPump.Level;
           yield return fuelPump.Get(level); // draw it empty
           yield return env.Timeout(TimeSpan.FromSeconds(level / RefuelingSpeed));

--- a/src/SimSharp/SimSharp.csproj
+++ b/src/SimSharp/SimSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>SimSharp.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
@@ -33,7 +33,7 @@ Sim# allows modeling processes easily and with little boiler plate code. A proce
     1) All of the RandXXX methods in class Simulation have been marked as obsolete.
     2) All of the random TimeoutXXX methods in class Simulation have been marked as obsolete.
 
-    To port code, it is advised to add &quot;using static SimSharp.Distributions&quot; to the using section and change e.g.
+    To port code, it is advised to add "using static SimSharp.Distributions" to the using section and change e.g.
     env.RandUniform(1, 2) to env.Rand(UNIF(1, 2))
     env.RandNormalPositive(3, 0.5) to env.Rand(POS(N(3, 0.5)))
     env.RandLogNormal(1, 2) to env.Rand(LNORM(1, 2))


### PR DESCRIPTION
Adds check for empty fuel pump before attempting to draw fuel
in GasStationRefueling sample, preventing an invalid get request
for 0 fuel. Note: this bug only materialises when attributes are
changed from current values such that an empty fuel pump occurs
during simulation.